### PR TITLE
Fix overriding global method for all `:sql-jdbc` drivers

### DIFF
--- a/src/metabase/driver/firebird.clj
+++ b/src/metabase/driver/firebird.clj
@@ -105,7 +105,7 @@
     ;; this point.
     (.execute stmt)))
 
-(defmethod sql-jdbc.sync/have-select-privilege? :sql-jdbc
+(defmethod sql-jdbc.sync/have-select-privilege? :firebird
   [driver conn table-schema table-name]
   ;; Query completes = we have SELECT privileges
   ;; Query throws some sort of no permissions exception = no SELECT privileges


### PR DESCRIPTION
The `:firebird` driver implements `sql-jdbc.sync/have-select-privilege?` for `:sql-jdbc` rather than `:firebird` which ultimately breaks the method for other drivers like Postgres, for example 

https://github.com/metabase/metabase/issues/32124

